### PR TITLE
Small change for Suma 'from' (used for FilterML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. [Description](#description)
 2. [Setup - The basics of getting started with aixautomation](#setup)
-    * [What aixautomation affects](#What-aixautomation-module-affects)
+    * [What aixautomation affects](#What-AixAutomation-module-affects)
     * [Setup requirements](#setup-requirements)
     * [Beginning with aixautomation](#beginning-with-aixautomation)
 3. [Usage - Configuration options and additional functionality](#usage)
@@ -65,7 +65,7 @@
   **- for AIX 7.2, 7.1**: https://s3.amazonaws.com/puppet-agents/2017.3/puppet-agent/5.3.5/repos/aix/7.1/PC1/ppc/puppet-agent-5.3.5-1.aix7.1.ppc.rpm<br>
   **- for AIX 6.1**: https://s3.amazonaws.com/puppet-agents/2017.3/puppet-agent/5.3.5/repos/aix/6.1/PC1/ppc/puppet-agent-5.3.5-1.aix6.1.ppc.rpm<br>
  Puppet rpm is installed using rpm -i command line.<br>  
- After Puppet installation, path to puppet is /opt/puppetlabs/puppet/bin/puppet.<br>
+ After Puppet installation, path to puppet is /opt/puppetlabs/bin/puppet.<br>
  Please note that Puppet comes with its own ruby, you'll find it here after Puppet installation:<br> 
     "/opt/puppetlabs/puppet/bin/ruby -version" returns "ruby 2.4.2p198 (2017-09-14 revision 59899)" 
   
@@ -160,19 +160,19 @@
  
 ### Command line    
   You can test './manifests/init.pp' manifest by using following command lines:<br>
-        /opt/puppetlabs/puppet/bin/puppet apply \ 
+        /opt/puppetlabs/bin/puppet apply \ 
           --noop --modulepath=/etc/puppetlabs/code/environments/production/modules \
           -e "include aixautomation"<br>
      or apply it without debug messages: <br>
-        /opt/puppetlabs/puppet/bin/puppet apply \
+        /opt/puppetlabs/bin/puppet apply \
           --modulepath=/etc/puppetlabs/code/environments/production/modules \
           -e "include aixautomation"<br>
      or apply it with debug messages: <br>
-        /opt/puppetlabs/puppet/bin/puppet apply  --debug \ 
+        /opt/puppetlabs/bin/puppet apply  --debug \ 
         --modulepath=/etc/puppetlabs/code/environments/production/modules \
           -e "include aixautomation"<br>
      or apply it with debug message and Puppet logs into a file: <br>
-        /opt/puppetlabs/puppet/bin/puppet apply \ 
+        /opt/puppetlabs/bin/puppet apply \ 
          --logdest=/etc/puppetlabs/code/environments/production/modules/output/logs/PuppetApply.log \
          --debug --modulepath=/etc/puppetlabs/code/environments/production/modules \
          -e "include aixautomation"<br>   
@@ -310,8 +310,10 @@ It is a good practice to regularly consider that the
  - <b>from</b>: attribute used to launch suma-download command, indicating the 
   starting level of desired updates. For example by indicating <b>7100-01</b>, 
   it means download contains everything to update from this <b>7100-01</b> 
-  technical level, or by indicating <b>7100-01-02-1150</b>, it means download 
-  contains everything to update from this <b>7100-01-02-1150</b> service pack.
+  technical level. Or by indicating <b>7100-01-02-1150</b>, it means download 
+  contains everything to update from this <b>7100-01-02-1150</b> service pack,
+  but specifying a SP into the <b>from</b> is equivalent to specifying the 
+  closest TL : <b>7100-01-02-1150</b> SP is equivalent to <b>7100-01</b> TL.
  - <b>to</b>: attribute used to launch suma-download command, indicating the 
   level of updates desired. For example by indicating <b>7100-03</b>, it means 
   download contains everything to update up to this <b>7100-03</b> technical 
@@ -426,13 +428,13 @@ It is a good practice to regularly consider that the
   first. It could occur that one particular eFix prevents another one (less 
   recent) from being installed if both eFixes touch the same file.<br>
  At the end of execution of this provider, you'll find into: <br>
-  - ./output/flrtvc/<target>_StatusBeforeEfixInstall.yml: how were the <target> 
+  - ./output/flrtvc/[target]_StatusBeforeEfixInstall.yml: how were the [target] 
     LPAR before eFix installation.<br> 
-  - ./output/flrtvc/<target>_StatusAfterEfixInstall.yml: how are the <target> 
+  - ./output/flrtvc/[target]_StatusAfterEfixInstall.yml: how are the [target] 
     LPARs after eFix installation.<br>
-  - ./output/flrtvc/<target>_StatusBeforeEfixRemoval.yml: how were the <target> 
+  - ./output/flrtvc/[target]_StatusBeforeEfixRemoval.yml: how were the [target] 
     LPAR before eFix de-installation.<br> 
-  - ./output/flrtvc/<target>_StatusAfterEfixRemoval.yml: how are the <target> 
+  - ./output/flrtvc/[target]_StatusAfterEfixRemoval.yml: how are the [target] 
     LPARs after eFix de-installation.<br>
  ##### Attributes
    - <b>provider</b>: this attribute is not mandatory, if mentioned it needs to 

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,10 @@
  10. Propose regex in targets parameter so that we can perform operations on a list of targets 
   generated from a regex.
  11. Check updates consistency before trying, by looking at the BUILDDATE from the "oslevel -s", 
-  and by comparing with BUILDDATE of the update.  
+  and by comparing with BUILDDATE of the update. 
+ 12. Maybe not judicious ro raise exception into Automation::Lib::Suma as these exceptions are not
+  caught and therefore they could interrupt execution, if thrown. 
+   
     
 
 

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -31,7 +31,7 @@ class aixautomation {
     ensure => present,
     type => "SP",
     root => "/tmp",
-    from => "7200-01-02-1717",
+    from => "7200-01",
     to => "7200-01-03-1720",
     to_step => "preview",
   }
@@ -122,15 +122,15 @@ class aixautomation {
   # This declaration allows to perform preview update only through nimpush provider:
   #  clio3 system update to the 7100-03-07-1614 SP is previewed.
   # The lpp_source is one NIM resource built by a 'download' declaration
-  #  PAA_SP_7100-03-05-1524_7100-03-07-1614
-  patchmngt { "update clio3 to PAA_SP_7100-03-05-1524_7100-03-07-1614":
+  #  PAA_SP_7100-03_7100-03-07-1614
+  patchmngt { "update clio3 to PAA_SP_7100-03_7100-03-07-1614":
     provider   => nimpush,
     ensure     => present,
-    name       => "update clio3 to PAA_SP_7100-03-05-1524_7100-03-07-1614",
+    name       => "update clio3 to PAA_SP_7100-03_7100-03-07-1614",
     action     => "update",
     targets    => "clio3",
     sync       => "yes",
-    lpp_source => "PAA_SP_7100-03-05-1524_7100-03-07-1614",
+    lpp_source => "PAA_SP_7100-03_7100-03-07-1614",
     preview    => "yes",
   }
 */
@@ -139,15 +139,15 @@ class aixautomation {
   # This declaration allows to perform update in apply mode through nimpush provider:
   #  clio3 system is updated to the 7100-03-07-1614 SP.
   # The lpp_source is one NIM resource built by a 'download' declaration
-  #  PAA_SP_7100-03-05-1524_7100-03-07-1614
-  patchmngt { "update clio3 to PAA_SP_7100-03-05-1524_7100-03-07-1614":
+  #  PAA_SP_7100-03_7100-03-07-1614
+  patchmngt { "update clio3 to PAA_SP_7100-03_7100-03-07-1614":
     provider   => nimpush,
     ensure     => present,
-    name       => "update clio3 to PAA_SP_7100-03-05-1524_7100-03-07-1614",
+    name       => "update clio3 to PAA_SP_7100-03_7100-03-07-1614",
     action     => "update",
     targets    => "clio3",
     sync       => "yes",
-    lpp_source => "PAA_SP_7100-03-05-1524_7100-03-07-1614",
+    lpp_source => "PAA_SP_7100-03_7100-03-07-1614",
     preview    => "no",
   }
   # This declaration allows to perform reject of all updates (which were applied only)
@@ -186,15 +186,15 @@ class aixautomation {
   # This declaration allows to perform update in apply mode through nimpush provider:
   #  clio4 system is updated to the 7100-03-08-1642 SP.
   # The lpp_source is one NIM resource built by a 'download' declaration
-  #  PAA_SP_7100-03-05-1524_7100-03-08-1642
-  patchmngt { "update clio4 to PAA_SP_7100-03-05-1524_7100-03-08-1642":
+  #  PAA_SP_7100-03_7100-03-08-1642
+  patchmngt { "update clio4 to PAA_SP_7100-03_7100-03-08-1642":
     provider   => nimpush,
     ensure     => present,
-    name       => "update clio4 to PAA_SP_7100-03-05-1524_7100-03-08-1642",
+    name       => "update clio4 to PAA_SP_7100-03_7100-03-08-1642",
     action     => "update",
     targets    => "clio4",
     sync       => "yes",
-    lpp_source => "PAA_SP_7100-03-05-1524_7100-03-08-1642",
+    lpp_source => "PAA_SP_7100-03_7100-03-08-1642",
   }
   # This declaration allows to perform commit of all updates (which were applied only)
   #  through nimpush provider: clio4 system keeps its previous level
@@ -304,16 +304,16 @@ class aixautomation {
 */
 /*
 class aixautomation {
-  download { "test PAA_SP_7200-01-02-1717_7200-01-03-1720":
+  download { "test PAA_SP_7200-01_7200-01-03-1720":
     provider => suma,
     ensure => present,
-    name => "test PAA_SP_7200-01-02-1717_7200-01-03-1720",
+    name => "test PAA_SP_7200-01_7200-01-03-1720",
     type => "SP",
     root => "/exports/extra/test-puppet/suma",
-    from => "7200-01-02-1717",
+    from => "7200-01",
     to => "7200-01-03-1720",
     to_step => "download",
-    lpp_source => "PAA_SP_7200-01-02-1717_7200-01-03-1720",
+    lpp_source => "PAA_SP_7200-01_7200-01-03-1720",
   }
   patchmngt { "update castor8 to 7200-01-03-1720":
     provider   => nimpush,
@@ -322,7 +322,7 @@ class aixautomation {
     action     => "update",
     targets    => "castor8",
     sync       => "yes",
-    lpp_source => "PAA_SP_7200-01-02-1717_7200-01-03-1720",
+    lpp_source => "PAA_SP_7200-01_7200-01-03-1720",
   }
   fix { "efix_install":
     provider => flrtvc,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,10 +2,10 @@
 #  /opt/puppetlabs/puppet/bin/puppet apply \
 #  --debug --modulepath=/etc/puppetlabs/code/environments/production/modules/ -e "include aixautomation"
 # This will trigger this suma command:
-#  /usr/sbin/suma -x  -a RqType=SP -a RqName=7200-01-03-1720 -a FilterML=7200-01-02-1717 \
-#   -a DisplayName="Downloading lppsources into /tmp/lpp_sources/SP/7200-01-02-1717/7200-01-03-1720" \
-#   -a Action=Preview -a DLTarget=/tmp/lpp_sources/SP/7200-01-02-1717/7200-01-03-1720 \
-#   -a FilterDir=/tmp/lpp_sources/SP/7200-01-02-1717/7200-01-03-1720
+#  /usr/sbin/suma -x  -a RqType=SP -a RqName=7200-01-03-1720 -a FilterML=7200-01 \
+#   -a DisplayName="Downloading lppsources into /tmp/lpp_sources/SP/7200-01/7200-01-03-1720" \
+#   -a Action=Preview -a DLTarget=/tmp/lpp_sources/SP/7200-01/7200-01-03-1720 \
+#   -a FilterDir=/tmp/lpp_sources/SP/7200-01/7200-01-03-1720
 class aixautomation {
   download { "test suma-preview":
     ensure  => present,
@@ -14,7 +14,7 @@ class aixautomation {
     #  directory in dedicated file system.
     # No need to change it to perform a 'preview'
     root    => "/tmp",
-    from    => "7200-01-02-1717",
+    from    => "7200-01",
     to      => "7200-01-03-1720",
     to_step => "preview",
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "aix-aixautomation",
-  "version": "0.6.5",
+  "version": "0.7",
   "author": "aix",
   "summary": "This module enables automation of suma/install and update/efix operations on a list of LPAR",
   "license": "Apache-2.0",


### PR DESCRIPTION
Changes to reflect the documentation (v0.7).
- Change puppet path.
- Specifying a SP into 'from' is like specifying the closest TL.